### PR TITLE
Features/allow searching in multiple environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,33 +1,28 @@
-haproxy_reloaded Cookbook
-===========================
+# haproxy_reloaded Cookbook
 
-Description
------------
+## Description
 
 This cookbook installs, configures and manages Haproxy.
 
-Requirements
-------------
+## Requirements
 
-#### Chef
+### Chef
 Tested on 11.12.8 but newer and older version should work just fine.
 
-#### Platform
+### Platform
 The following platforms have been tested with this cookbook, meaning that the recipes run on these platforms without error:
 - `Ubuntu`
 - `Debian`
 
-#### Cookbooks
+### Cookbooks
 
 There are **no** external cookbook dependencies.
 
-Capabilities
-------------
+## Capabilities
 
-Attributes
-----------
+## Attributes
 
-#### haproxy_reloaded::default
+### haproxy_reloaded::default
 <table>
   <tr>
     <th>Key</th>
@@ -81,25 +76,21 @@ Attributes
 
 For more details, see the `attributes/default.rb` file.
 
-Recipes
--------
+## Recipes
 
 ### haproxy_reloaded::default
 This recipe installs and configures Haproxy in the node.
 
-Resources and Providers
------------------------
+## Resources and Providers
 
 There are **none** defined.
 
-Libraries
----------
+## Libraries
 
 ### haproxy_reloaded::generate_content
 This library contains the functions that parse the node attributes and generate the haproxy configuration file.
 
-Usage
------
+## Usage
 
 Just include `haproxy_reloaded` in your node's `run_list`:
 
@@ -123,7 +114,8 @@ You can disable listen, frontend or backend sections configured in other roles b
 The special attribute ```[member_options]``` is an hash that set rules to search the servers and the configurations to be applied them by setting the following attributes:
 
 - ```[member_options]['search']```: You need to define the Chef search string in order to obtain the nodes IP that will be used in the Haproxy server parameters
-- ```[member_options]['search_extra_environments']```: You can extend the search query to other chef environments than the node's one. This can be useful when you have multiple clusters for the same environment. (Default is `nil`)
+- ```[member_options]['search_extra_environments']```: You can extend the search query to other chef environments than the node's one. This allows you to send the same trafic to multiple clusters. (Default is `nil`)
+- ```[member_options]['search_environments']```: You can also completely replace the chef environments used to search for the nodes. This allows you to send different trafics to different clusters. (Default is `nil`)
 - ```[member_options]['port']```:  You should set the port where is running the nodes service that will be managed by Haproxy
 - ```[member_options]['options']```: This attribute should contain all the options that you need to set to the servers
 
@@ -528,16 +520,24 @@ listen health
         option tcplog
 ```
 
-In any cases, this cookbook will scope the `search` with the node's chef
+### Forwarding the same trafic to multiple clusters
+
+By default this cookbook will scope the `search` with the node's chef
 environment, but you can enlarge the search scope by adding more chef 
 environments in the `search_extra_environments` attribute:
 
 ```json
 "haproxy": {
+  "frontend": {
+    "http": {
+      "bind": "*:80",
+      "default_backend": "webstomp"
+    }
+  },
   "backend": {
     "webstomp": {
       "servers": {
-        "search": "policy_name:k8smaster",
+        "search": "policy_name:k8sworker",
         "search_extra_environments": ["staging-west"]
       }
     }
@@ -545,13 +545,45 @@ environments in the `search_extra_environments` attribute:
 }
 ```
 
-In the bellow example all the nodes having the `policy_name` being `k8smaster`
-and being part of the node's `chef_environment` (`staging-east` for example) 
-**AND** the nodes from the `staging-west` `chef_environment` will be included in
-the HAproxy configuration.
+Let's suppose that the trafic for `a.example.com` and `b.example.com` is coming
+to the load balancer port 80, both will be forwarded to the servers from the
+`webstomp` backend.
 
-Development
------------
+### Forwarding different trafics to different clusters
+
+But you can also completely replace the chef environments used in the search 
+query in order to *split* the trafic:
+
+```json
+"haproxy": {
+  "frontend": {
+    "http": {
+      "bind": "*:80",
+      "use_backend": "%[req.hdr(host),lower,word(1,:)]"
+    }
+  },
+  "backend": {
+    "a.example.com": {
+      "servers": {
+        "search": "policy_name:k8sworker",
+        "search_environments": ["staging-app-a"]
+      }
+    },
+    "b.example.com": {
+      "servers": {
+        "search": "policy_name:k8sworker",
+        "search_environments": ["staging-app-b"]
+      }
+    }
+  }
+```
+
+Here the trafic to `a.example.com` will be forwarded to the nodes from the
+`staging-app-a` chef environment (or policy group), while the trafic to 
+`b.example.com` will be forwarded to the nodes from the `staging-app-b` chef 
+environment (or policy group).
+
+## Development
 
 - Source hosted at [GitHub][repo]
 - Report issues/Questions/Feature requests on [GitHub Issues][issues]

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ You can disable listen, frontend or backend sections configured in other roles b
 The special attribute ```[member_options]``` is an hash that set rules to search the servers and the configurations to be applied them by setting the following attributes:
 
 - ```[member_options]['search']```: You need to define the Chef search string in order to obtain the nodes IP that will be used in the Haproxy server parameters
+- ```[member_options]['search_extra_environments']```: You can extend the search query to other chef environments than the node's one. This can be useful when you have multiple clusters for the same environment. (Default is `nil`)
 - ```[member_options]['port']```:  You should set the port where is running the nodes service that will be managed by Haproxy
 - ```[member_options]['options']```: This attribute should contain all the options that you need to set to the servers
 
@@ -526,6 +527,28 @@ listen health
         mode health
         option tcplog
 ```
+
+In any cases, this cookbook will scope the `search` with the node's chef
+environment, but you can enlarge the search scope by adding more chef 
+environments in the `search_extra_environments` attribute:
+
+```json
+"haproxy": {
+  "backend": {
+    "webstomp": {
+      "servers": {
+        "search": "policy_name:k8smaster",
+        "search_extra_environments": ["staging-west"]
+      }
+    }
+  }
+}
+```
+
+In the bellow example all the nodes having the `policy_name` being `k8smaster`
+and being part of the node's `chef_environment` (`staging-east` for example) 
+**AND** the nodes from the `staging-west` `chef_environment` will be included in
+the HAproxy configuration.
 
 Development
 -----------

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -56,6 +56,9 @@ default['haproxy']['backend'] = {}
 #    },
 #    'member_options' => {
 #      'search' => 'role:webserver',
+#      'search_extra_environments' => [
+#        'another-environment-name'
+#      ],
 #      'port' => "80",
 #      'options' => "cookie #{server['hostname']} check port 80"
 #    }

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -56,9 +56,6 @@ default['haproxy']['backend'] = {}
 #    },
 #    'member_options' => {
 #      'search' => 'role:webserver',
-#      'search_extra_environments' => [
-#        'another-environment-name'
-#      ],
 #      'port' => "80",
 #      'options' => "cookie #{server['hostname']} check port 80"
 #    }

--- a/libraries/generate_content.rb
+++ b/libraries/generate_content.rb
@@ -44,7 +44,15 @@ def parse_servers_hash(servers)
   end
 
   unless servers['search'].nil?
-    pool_servers = search("node", "#{servers['search']} AND chef_environment:#{node.chef_environment}") || []
+    chef_environments = "chef_environment:#{node.chef_environment}"
+
+    unless servers['search_extra_environments'].nil?
+      servers['search_extra_environments'].map do |extra_env|
+        chef_environments += " OR chef_environment:#{extra_env}"
+      end
+    end
+
+    pool_servers = search('node', "#{servers['search']} AND (#{chef_environments})") || []
 
     pool_servers = pool_servers.sort { |a,b| a[:hostname] <=> b[:hostname] }
 

--- a/libraries/generate_content.rb
+++ b/libraries/generate_content.rb
@@ -61,10 +61,14 @@ def parse_servers_hash(servers)
     unless servers['search_environments'].nil?
       chef_environments = ''
 
-      servers['search_environments'].map do |extra_env|
-        chef_environments += " OR chef_environment:#{extra_env}"
+      servers['search_environments'].each_with_index do |extra_env, index|
+        chef_environments += "chef_environment:#{extra_env}"
+
+        chef_environments += ' OR ' if index < servers['search_environments'].size
       end
     end
+
+    Chef::Log.info "\n  )-----> chef_environments: #{chef_environments.inspect}"
 
     pool_servers = search('node', "#{servers['search']} AND (#{chef_environments})") || []
 

--- a/libraries/generate_content.rb
+++ b/libraries/generate_content.rb
@@ -50,8 +50,8 @@ def parse_servers_hash(servers)
 
     pool_servers.map! do |server|
       server_ip = begin
-        if server.attribute?('cloud')
-          if node.attribute?('cloud') && (server['cloud']['provider'] == node['cloud']['provider'])
+        if server['cloud']
+          if node['cloud'] && (server['cloud']['provider'] == node['cloud']['provider'])
             server['cloud']['local_ipv4']
           else
             server['cloud']['public_ipv4']

--- a/libraries/generate_content.rb
+++ b/libraries/generate_content.rb
@@ -64,7 +64,8 @@ def parse_servers_hash(servers)
       servers['search_environments'].each_with_index do |extra_env, index|
         chef_environments += "chef_environment:#{extra_env}"
 
-        chef_environments += ' OR ' if index < servers['search_environments'].size
+        index < (servers['search_environments'].size - 1) &&
+          chef_environments += ' OR '
       end
     end
 


### PR DESCRIPTION
### Forwarding the same trafic to multiple clusters

By default this cookbook will scope the `search` with the node's chef environment, but you can enlarge the search scope by adding more chef environments in the `search_extra_environments` attribute:

```json
"haproxy": {
  "frontend": {
    "http": {
      "bind": "*:80",
      "default_backend": "webstomp"
    }
  },
  "backend": {
    "webstomp": {
      "servers": {
        "search": "policy_name:k8sworker",
        "search_extra_environments": ["staging-west"]
      }
    }
  }
}
```

Let's suppose that the trafic for `a.example.com` and `b.example.com` is coming to the load balancer port 80, both will be forwarded to the servers from the `webstomp` backend.

### Forwarding different trafics to different clusters

But you can also completely replace the chef environments used in the search query in order to *split* the trafic:

```json
"haproxy": {
  "frontend": {
    "http": {
      "bind": "*:80",
      "use_backend": "%[req.hdr(host),lower,word(1,:)]"
    }
  },
  "backend": {
    "a.example.com": {
      "servers": {
        "search": "policy_name:k8sworker",
        "search_environments": ["staging-app-a"]
      }
    },
    "b.example.com": {
      "servers": {
        "search": "policy_name:k8sworker",
        "search_environments": ["staging-app-b"]
      }
    }
  }
```

Here the trafic to `a.example.com` will be forwarded to the nodes from the `staging-app-a` chef environment (or policy group), while the trafic to `b.example.com` will be forwarded to the nodes from the `staging-app-b` chef environment (or policy group).
